### PR TITLE
fixtures: add `metadata.generator` to stream metadata

### DIFF
--- a/tests/it/fixtures/fcos-stream.json
+++ b/tests/it/fixtures/fcos-stream.json
@@ -1,7 +1,8 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2020-12-17T14:18:43Z"
+        "last-modified": "2020-12-17T14:18:43Z",
+        "generator": "fedora-coreos-stream-generator v0"
     },
     "architectures": {
         "x86_64": {


### PR DESCRIPTION
Spec update: https://github.com/coreos/fedora-coreos-tracker/pull/962