### PR TITLE
Add support for IBMCloud/PowerVS images

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ pub struct GcpImage {
     pub name: String,
 }
 
-/// ReplicatedObject storage images for clouds like IBMCloud/PowerVS
+/// Objects in an object store for each region, such as on IBMCloud or PowerVS.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct ReplicatedObject {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ pub struct ReplicatedObject {
     pub regions: HashMap<String, RegionObject>,
 }
 
-/// RegionObject like the ones used for IBMCloud/PowerVS platform containing release, object, bucket and url .
+/// Region-specific object in an object store, such as on IBMCloud or PowerVS.
 #[derive(Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub struct RegionObject {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,28 @@ pub struct GcpImage {
     pub name: String,
 }
 
+/// ReplicatedObject storage images for clouds like IBMCloud/PowerVS
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct ReplicatedObject {
+    /// Mapping from region name to the object.
+    pub regions: HashMap<String, RegionObject>,
+}
+
+/// RegionObject like the ones used for IBMCloud/PowerVS platform containing release, object, bucket and url .
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub struct RegionObject {
+    /// The release version of FCOS.
+    pub release: String,
+    /// The actual object in the cloud object storage (.ova.gz for PowerVS, .qcow2 for IBMCloud)
+    pub object: String,
+    /// The bucket where the object resides.
+    pub bucket: String,
+    /// The url of the object.
+    pub url: String,
+}
+
 /// Public cloud images.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -107,6 +129,10 @@ pub struct Images {
     pub aws: Option<AwsImages>,
     /// Images for GCP.
     pub gcp: Option<GcpImage>,
+    /// Objects for IBMCloud
+    pub ibmcloud: Option<ReplicatedObject>,
+    /// Objects for PowerVS
+    pub powervs: Option<ReplicatedObject>,
 }
 
 impl Stream {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ pub struct ReplicatedObject {
 pub struct RegionObject {
     /// The release version of FCOS.
     pub release: String,
-    /// The actual object in the cloud object storage (.ova.gz for PowerVS, .qcow2 for IBMCloud)
+    /// The name of the object in the object store.
     pub object: String,
     /// The bucket where the object resides.
     pub bucket: String,


### PR DESCRIPTION
Adding support for IBMCloud/PowerVS objects to be added to the stream.

similar to https://github.com/coreos/stream-metadata-go/pull/35