### PR TITLE
Add release field to `GcpImage`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,9 @@ pub struct AwsRegionImage {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct GcpImage {
+    /// The release version of FCOS.
+    // Legacy metadata doesn't have this
+    pub release: Option<String>,
     /// The project ID.
     pub project: String,
     /// The image family.


### PR DESCRIPTION
Since the image name is version-specific, we should include a release field here to record the corresponding OS version.  Stream metadata supports version skew between different platforms (e.g. to avoid a platform-specific regression in a release) and we're generally explicit about the version of each artifact.

xref https://github.com/coreos/stream-metadata-go/pull/36