### PR TITLE
Improve test error reporting on parse failure; move anyhow to dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
-anyhow = "1.0"
 nix = ">= 0.20, < 0.24"
 serde = { version = "^1.0", features = ["derive"] }
 strum = ">= 0.20, < 0.23"
 strum_macros = ">= 0.20, < 0.23"
 
 [dev-dependencies]
+anyhow = "1.0"
 serde_json = "1.0"

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -1,11 +1,10 @@
-use anyhow::Result;
 use coreos_stream_metadata::Stream;
 use coreos_stream_metadata::{fcos, AwsRegionImage};
 
 const STREAM_DATA: &[u8] = include_bytes!("fixtures/fcos-stream.json");
 
 #[test]
-fn test_basic() -> Result<()> {
+fn test_basic() {
     assert_eq!(
         fcos::StreamID::Stable.url(),
         "https://builds.coreos.fedoraproject.org/streams/stable.json"
@@ -14,7 +13,7 @@ fn test_basic() -> Result<()> {
     let un = nix::sys::utsname::uname();
     let myarch = un.machine();
 
-    let st: Stream = serde_json::from_slice(STREAM_DATA)?;
+    let st: Stream = serde_json::from_slice(STREAM_DATA).unwrap();
     assert_eq!(st.stream, "stable");
     let a = st.architectures.get("x86_64").unwrap();
     if myarch == "x86_64" {
@@ -58,6 +57,4 @@ fn test_basic() -> Result<()> {
             release: "33.20201201.3.0".to_string(),
         }
     );
-
-    Ok(())
 }


### PR DESCRIPTION
Have the test fail on an assertion immediately, rather than generically reporting that the test function returned `Err`.

As a result, we only need anyhow for one doctest; move it to dev-dependencies.  Libraries shouldn't use it in their public API anyway, so it's safer to keep it out of regular deps.