### PR TITLE
Add KubeVirt containerdisk to the stream metadata

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,14 @@ pub struct ReplicatedObject {
     pub regions: HashMap<String, RegionObject>,
 }
 
+/// ContainerDisk for KubeVirt
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct KubeVirtContainerDisk {
+    /// image reference to the container disk in a container registry
+    pub image: String,
+}
+
 /// Region-specific object in an object store, such as on IBMCloud or PowerVS.
 #[derive(Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
@@ -136,6 +144,8 @@ pub struct Images {
     pub ibmcloud: Option<ReplicatedObject>,
     /// Objects for PowerVS
     pub powervs: Option<ReplicatedObject>,
+    /// ContainerDisk for KubeVirt
+    pub kubevirt: Option<KubeVirtContainerDisk>,
 }
 
 impl Stream {

--- a/tests/it/fixtures/fcos-stream.json
+++ b/tests/it/fixtures/fcos-stream.json
@@ -272,6 +272,9 @@
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
                     "name": "fedora-coreos-33-20201201-3-0-gcp-x86-64"
+                },
+                "kubevirt": {
+                    "image": "quay.io/openshift-release-dev/rhcos@sha256:67a81539946ec0397196c145394553b8e0241acf27b14ae9de43bc56e167f773"
                 }
             }
         }

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -57,4 +57,15 @@ fn test_basic() {
             release: "33.20201201.3.0".to_string(),
         }
     );
+
+    assert_eq!(
+        a.images
+            .as_ref()
+            .unwrap()
+            .kubevirt
+            .as_ref()
+            .unwrap()
+            .image,
+        "quay.io/openshift-release-dev/rhcos@sha256:67a81539946ec0397196c145394553b8e0241acf27b14ae9de43bc56e167f773".to_string()
+    );
 }


### PR DESCRIPTION
KubeVirt consumes directly a qcow2 disk inside a container which
is described in the images section. It is based on the qcow2 from the
base artifacts for kubevirt.

This schema extension is needed to include informations about containerDisks created in https://github.com/coreos/coreos-assembler/pull/2750.