### PR TITLE
Rename AWS image structs to be generic; switch KubeVirt to generic struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,14 +117,6 @@ pub struct ReplicatedObject {
     pub regions: HashMap<String, RegionObject>,
 }
 
-/// ContainerDisk for KubeVirt
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub struct KubeVirtContainerDisk {
-    /// image reference to the container disk in a container registry
-    pub image: String,
-}
-
 /// Region-specific object in an object store, such as on IBMCloud or PowerVS.
 #[derive(Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
@@ -152,7 +144,7 @@ pub struct Images {
     /// Objects for PowerVS
     pub powervs: Option<ReplicatedObject>,
     /// ContainerDisk for KubeVirt
-    pub kubevirt: Option<KubeVirtContainerDisk>,
+    pub kubevirt: Option<SingleImage>,
 }
 
 impl Stream {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,21 +69,28 @@ pub struct Artifact {
     pub signature: Option<String>,
 }
 
-/// Image for Amazon Web Services (EC2).
+/// Alias for backward compatibility
+pub type AwsImages = ReplicatedImage;
+
+/// Alias for backward compatibility
+pub type AwsRegionImage = SingleImage;
+
+/// An image in all regions of an AWS-like cloud
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
-pub struct AwsImages {
-    /// Mapping from region name to AMI.
-    pub regions: HashMap<String, AwsRegionImage>,
+pub struct ReplicatedImage {
+    /// Mapping from region name to image
+    pub regions: HashMap<String, SingleImage>,
 }
 
-/// A pair of an AWS image (AMI) and the release version.
+/// An globally-accessible image or an image in a single region of an
+/// AWS-like cloud
 #[derive(Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
-pub struct AwsRegionImage {
+pub struct SingleImage {
     /// The release version of FCOS.
     pub release: String,
-    /// AMI (HVM).
+    /// Image reference
     pub image: String,
 }
 
@@ -137,7 +144,7 @@ pub struct RegionObject {
 #[serde(rename_all = "kebab-case")]
 pub struct Images {
     /// Images for AWS.
-    pub aws: Option<AwsImages>,
+    pub aws: Option<ReplicatedImage>,
     /// Images for GCP.
     pub gcp: Option<GcpImage>,
     /// Objects for IBMCloud

--- a/tests/it/fixtures/fcos-stream.json
+++ b/tests/it/fixtures/fcos-stream.json
@@ -269,11 +269,13 @@
                     }
                 },
                 "gcp": {
+                    "release": "33.20201201.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
                     "name": "fedora-coreos-33-20201201-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
+                    "release": "33.20201201.3.0",
                     "image": "quay.io/openshift-release-dev/rhcos@sha256:67a81539946ec0397196c145394553b8e0241acf27b14ae9de43bc56e167f773"
                 }
             }

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -64,8 +64,10 @@ fn test_basic() {
             .unwrap()
             .kubevirt
             .as_ref()
-            .unwrap()
-            .image,
-        "quay.io/openshift-release-dev/rhcos@sha256:67a81539946ec0397196c145394553b8e0241acf27b14ae9de43bc56e167f773".to_string()
+            .unwrap(),
+        &SingleImage {
+            image: "quay.io/openshift-release-dev/rhcos@sha256:67a81539946ec0397196c145394553b8e0241acf27b14ae9de43bc56e167f773".to_string(),
+            release: "33.20201201.3.0".to_string(),
+        }
     );
 }

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -1,5 +1,5 @@
 use coreos_stream_metadata::Stream;
-use coreos_stream_metadata::{fcos, AwsRegionImage};
+use coreos_stream_metadata::{fcos, SingleImage};
 
 const STREAM_DATA: &[u8] = include_bytes!("fixtures/fcos-stream.json");
 
@@ -52,7 +52,7 @@ fn test_basic() {
             .regions
             .get("us-east-1")
             .unwrap(),
-        &AwsRegionImage {
+        &SingleImage {
             image: "ami-037a0ba6d14ca2e05".to_string(),
             release: "33.20201201.3.0".to_string(),
         }


### PR DESCRIPTION
Match the struct names used in stream-metadata-go.

xref https://github.com/coreos/stream-metadata-go/pull/44

cc @rmohr