### PR TITLE
Add digest reference to KubeVirt image description

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,18 @@ pub struct SingleImage {
     pub image: String,
 }
 
+/// A tagged container image
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub struct ContainerImage {
+    /// The release version of FCOS.
+    pub release: String,
+    /// Preferred way to reference the image, which might be by tag or digest
+    pub image: String,
+    /// Image reference by digest
+    pub digest_ref: String,
+}
+
 /// Image stored in Google Compute Platform.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -144,7 +156,7 @@ pub struct Images {
     /// Objects for IBMCloud
     pub ibmcloud: Option<ReplicatedObject>,
     /// ContainerDisk for KubeVirt
-    pub kubevirt: Option<SingleImage>,
+    pub kubevirt: Option<ContainerImage>,
     /// Objects for PowerVS
     pub powervs: Option<ReplicatedObject>,
 }

--- a/tests/it/fixtures/fcos-stream.json
+++ b/tests/it/fixtures/fcos-stream.json
@@ -284,7 +284,8 @@
                 },
                 "kubevirt": {
                     "release": "33.20201201.3.0",
-                    "image": "quay.io/openshift-release-dev/rhcos@sha256:67a81539946ec0397196c145394553b8e0241acf27b14ae9de43bc56e167f773"
+                    "image": "quay.io/openshift-release-dev/rhcos:stable",
+                    "digest-ref": "quay.io/openshift-release-dev/rhcos@sha256:67a81539946ec0397196c145394553b8e0241acf27b14ae9de43bc56e167f773"
                 }
             }
         }

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -1,5 +1,5 @@
 use coreos_stream_metadata::Stream;
-use coreos_stream_metadata::{fcos, SingleImage};
+use coreos_stream_metadata::{fcos, ContainerImage, SingleImage};
 
 const STREAM_DATA: &[u8] = include_bytes!("fixtures/fcos-stream.json");
 
@@ -65,8 +65,9 @@ fn test_basic() {
             .kubevirt
             .as_ref()
             .unwrap(),
-        &SingleImage {
-            image: "quay.io/openshift-release-dev/rhcos@sha256:67a81539946ec0397196c145394553b8e0241acf27b14ae9de43bc56e167f773".to_string(),
+        &ContainerImage {
+            image: "quay.io/openshift-release-dev/rhcos:stable".to_string(),
+            digest_ref: "quay.io/openshift-release-dev/rhcos@sha256:67a81539946ec0397196c145394553b8e0241acf27b14ae9de43bc56e167f773".to_string(),
             release: "33.20201201.3.0".to_string(),
         }
     );


### PR DESCRIPTION
In the current design, the KubeVirt image is presumed to be a fully-qualified reference, including a container digest.  But that implies that the user should reference the image by digest, when we'd prefer that they reference it by stream-specific tag.

Define the existing `image` field to contain the preferred form of fully-qualified reference for the image, which might involve either a tag or a digest.  We should still record the unique identifier of the current image (as we do for GCP images), so add a `digest-ref` field which always contains a fully-qualified reference with digest.

xref https://github.com/coreos/stream-metadata-go/pull/46