### PR TITLE
Added support for Aliyun cloud images in stream-metadata-rust library

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,16 +135,18 @@ pub struct RegionObject {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Images {
+    /// Images for Aliyun
+    pub aliyun: Option<ReplicatedImage>,
     /// Images for AWS.
     pub aws: Option<ReplicatedImage>,
     /// Images for GCP.
     pub gcp: Option<GcpImage>,
     /// Objects for IBMCloud
     pub ibmcloud: Option<ReplicatedObject>,
-    /// Objects for PowerVS
-    pub powervs: Option<ReplicatedObject>,
     /// ContainerDisk for KubeVirt
     pub kubevirt: Option<SingleImage>,
+    /// Objects for PowerVS
+    pub powervs: Option<ReplicatedObject>,
 }
 
 impl Stream {

--- a/tests/it/fixtures/fcos-stream.json
+++ b/tests/it/fixtures/fcos-stream.json
@@ -184,6 +184,14 @@
                 }
             },
             "images": {
+                "aliyun":{
+                    "regions": {
+                        "us-east-1": {
+                            "release": "33.20201201.3.0",
+                            "image": "m-0xi29kf08acv9dps47zs"
+                        }
+                    }                    
+                },
                 "aws": {
                     "regions": {
                         "af-south-1": {

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -70,4 +70,20 @@ fn test_basic() {
             release: "33.20201201.3.0".to_string(),
         }
     );
+
+    assert_eq!(
+        a.images
+            .as_ref()
+            .unwrap()
+            .aliyun
+            .as_ref()
+            .unwrap()
+            .regions
+            .get("us-east-1")
+            .unwrap(),
+        &SingleImage {
+            image: "m-0xi29kf08acv9dps47zs".to_string(),
+            release: "33.20201201.3.0".to_string(),
+        }
+    );
 }


### PR DESCRIPTION
support added to "lib.rs" for the Aliyun cloud images
tests added to "main.rs" to cover the Aliyun cloud images
fixture updated in "fcos-stream.json"  to include example Aliyun cloud images

Resolves issue https://issues.redhat.com/browse/COS-1355
