### PR TITLE
dependabot: switch to weekly cadence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: cargo
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 10
   labels:
   - dependency


### PR DESCRIPTION
Daily Dependabot updates are generating too much PR noise.  Reduce to weekly.