### PR TITLE
cargo: update to nix >= 0.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
-nix = ">= 0.20, < 0.24"
+nix = ">= 0.24, < 0.26"
 serde = { version = "^1.0", features = ["derive"] }
 strum = ">= 0.20, < 0.25"
 strum_macros = ">= 0.20, < 0.25"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
-nix = ">= 0.24, < 0.26"
+nix = { version = ">= 0.24, < 0.26", default-features = false, features = ["feature"] }
 serde = { version = "^1.0", features = ["derive"] }
 strum = ">= 0.20, < 0.25"
 strum_macros = ">= 0.20, < 0.25"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,8 +164,14 @@ pub struct Images {
 impl Stream {
     /// Returns the data for the CPU architecture matching the running process.
     pub fn this_architecture(&self) -> Option<&Arch> {
-        let un = nix::sys::utsname::uname();
-        self.architectures.get(un.machine())
+        self.architectures.get(
+            // uname() shouldn't fail, and our return type assumes it won't.
+            nix::sys::utsname::uname()
+                .expect("couldn't get utsname")
+                .machine()
+                .to_str()
+                .expect("utsname machine isn't UTF-8"),
+        )
     }
 
     /// Find a `disk` artifact.

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -10,8 +10,8 @@ fn test_basic() {
         "https://builds.coreos.fedoraproject.org/streams/stable.json"
     );
 
-    let un = nix::sys::utsname::uname();
-    let myarch = un.machine();
+    let un = nix::sys::utsname::uname().unwrap();
+    let myarch = un.machine().to_str().unwrap();
 
     let st: Stream = serde_json::from_slice(STREAM_DATA).unwrap();
     assert_eq!(st.stream, "stable");


### PR DESCRIPTION
`uname()` can now fail, and now returns an `&OsStr` that might not be UTF-8.  Both of these error cases are really only theoretical, and we can't switch to returning a `Result` without breaking API.  (And in fact, nothing in the crate currently returns a `Result`.)  Just return `None` in both of these cases.

Also enable only the nix functionality we use, since nix 0.24 added detailed feature flags.