### PR TITLE
Add a `this_architecture()` API, drop nix dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
-nix = { version = ">= 0.24, < 0.26", default-features = false, features = ["feature"] }
 serde = { version = "^1.0", features = ["derive"] }
 strum = ">= 0.20, < 0.25"
 strum_macros = ">= 0.20, < 0.25"

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -10,8 +10,7 @@ fn test_basic() {
         "https://builds.coreos.fedoraproject.org/streams/stable.json"
     );
 
-    let un = nix::sys::utsname::uname().unwrap();
-    let myarch = un.machine().to_str().unwrap();
+    let myarch = coreos_stream_metadata::this_architecture();
 
     let st: Stream = serde_json::from_slice(STREAM_DATA).unwrap();
     assert_eq!(st.stream, "stable");


### PR DESCRIPTION
Motivated by wanting similar code that I was going to add to zincati https://github.com/coreos/zincati/pull/876/files#diff-e21568cc43324fc7c1b72a7f5e92260a33ff8e7a39a9166823db9976be98649bR192

But, mirroring the stream-metadata-go change, let's add the API here.

Notably, this lets us also drop the nix dependency, which is valuable because nix keeps bumping semver and it's a nontrivial expensive dependency.