### PR TITLE
Bump to 2021 edition + Remove `authors` entry

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,8 +12,6 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  # Minimum supported Rust version (MSRV)
-  ACTIONS_MSRV_TOOLCHAIN: 1.49.0
   # Pinned toolchain for linting
   ACTIONS_LINTS_TOOLCHAIN: 1.64.0
 
@@ -39,10 +37,17 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Detect crate MSRV
+        shell: bash
+        run: |
+          msrv=$(cargo metadata --format-version 1 --no-deps | \
+              jq -r '.packages | .[].rust_version')
+          echo "Crate MSRV: $msrv"
+          echo "MSRV=$msrv" >> $GITHUB_ENV
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env['ACTIONS_MSRV_TOOLCHAIN']  }}
+          toolchain: ${{ env.MSRV }}
           default: true
       - name: cargo build
         run: cargo build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "coreos-stream-metadata"
 version = "0.1.0"
 authors = ["Colin Walters <walters@verbum.org>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "coreos-stream-metadata"
 version = "0.1.0"
-authors = ["Colin Walters <walters@verbum.org>"]
 edition = "2021"
 license = "Apache-2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "coreos-stream-metadata"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
+rust-version = "1.60.0"
 
 [dependencies]
 serde = { version = "^1.0", features = ["derive"] }


### PR DESCRIPTION
Bump to 2021 edition

No changes, just keeping up with the times.

---

Remove `authors` entry

`git log` is canonical for this, no reason to have the person
who happened to create the project be listed explicitly here.
As of recent Rust, this field is no longer required, probably
for that reason.

---

