### PR TITLE
Drop MSRV to 1.58

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/coreos/stream-metadata-rust"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
-rust-version = "1.60.0"
+rust-version = "1.58.0"
 
 [dependencies]
 serde = { version = "^1.0", features = ["derive"] }


### PR DESCRIPTION
Per discussion in chat, this is a current lower baseline across other coreos repos.