### PR TITLE
Add API to query disk with version

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ pub struct Arch {
 #[derive(Debug, Deserialize)]
 pub struct Platform {
     /// The release version number.
+    pub release: String,
     /// Specific formats.
     pub formats: HashMap<String, HashMap<String, Artifact>>,
 }
@@ -175,6 +176,20 @@ impl Stream {
             .and_then(|a| a.artifacts.get(artifact))
             .and_then(|p| p.formats.get(format_name))
             .and_then(|p| p.get("disk"))
+    }
+
+    /// Find a `disk` artifact with its version.
+    pub fn query_disk_and_version(
+        &self,
+        arch: &str,
+        artifact: &str,
+        format_name: &str,
+    ) -> Option<(&Artifact, &str)> {
+        let arch = self.architectures.get(arch)?;
+        let artifact = arch.artifacts.get(artifact)?;
+        let fmt = artifact.formats.get(format_name)?;
+        let disk = fmt.get("disk")?;
+        Some((disk, artifact.release.as_str()))
     }
 
     /// Find the single `disk` image for this architecture of the given type.  Only use this

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -42,6 +42,17 @@ fn test_basic() {
     );
 
     assert_eq!(
+        st.query_disk_and_version("x86_64", "metal", "raw.xz")
+            .as_ref()
+            .map(|(d, v)| (d.sha256.as_str(), *v))
+            .unwrap(),
+        (
+            "2848b111a6917455686f38a3ce64d2321c33809b9cf796c5f6804b1c02d79d9d",
+            "33.20201201.3.0"
+        )
+    );
+
+    assert_eq!(
         a.images
             .as_ref()
             .unwrap()


### PR DESCRIPTION
Add `release` to `Platform`

This was missing, but is very useful to know the version number
of things.

---

Add API to query disk with version

This is useful for e.g. downloader tools, which want
to know the version.

---

